### PR TITLE
Detect attachment MIME type using file bash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ The rspamd plugin can insert the following symbols inside the mail header:
 - `YOMI_UNKNOWN`: the Sandbox wasn't able to compute a score for the file
 - `YOMI_WAIT`: if the file is being processed inside the Sandbox, also add the CLAM_VIRUS_FAIL symbol to handle the soft reject
 - `YOMI_UNAUTHORIZED`: if the proxy cannot grant authentication or authorization
-- `YOMI_SKIPPED`: if YOMI check was skipped because the sender is authenticated or the mime type of the file is considered safe. By default PDF, HTML, EPUB and text files are considered safe
+- `YOMI_SKIPPED`: if YOMI check was skipped because the sender is authenticated or the MIME type of the file is considered safe

--- a/yomi.lua
+++ b/yomi.lua
@@ -185,18 +185,14 @@ local function get_mime_type(file_name, task, content, rule)
   local attachment_fd = rspamd_util.create_file(attachment_filename)
   content:save_in_file(attachment_fd)
 
-  -- rspamd_logger.infox(task, string.format('attachment_filename:  %s', attachment_filename)) -- ////
-
   local handle = io.popen('/usr/bin/file -b --mime-type ' .. attachment_filename)
   local result = handle:read("*a")
   local mime_type = string.gsub(result, "\n", "")
   handle:close()
 
-  -- rspamd_logger.infox(task, '#' .. mime_type .. '#') -- ////
-
   task:get_mempool():add_destructor(function()
-    os.remove(attachment_filename)
     rspamd_util.close_file(attachment_fd)
+    os.remove(attachment_filename)
   end)
 
   return mime_type


### PR DESCRIPTION
`file --mime-type` bash command is much more effective than rspamd `mime_part:get_detected_ext()` in detecting attachment MIME type.